### PR TITLE
Tab fix 01

### DIFF
--- a/main.go
+++ b/main.go
@@ -543,6 +543,10 @@ func deleteEmpty(s []string) []string {
 func handleInput(viewName string) error {
 	clearView(viewName)
 	inputString, _ := getInputString(viewName)
+	if newViewTitle := getViewTitle(viewName); newViewTitle != "" {
+		// restore any tab completion view titles on input commit
+		setViewTitle(viewName, newViewTitle)
+	}
 	if inputString == "" {
 		return nil
 	}
@@ -567,10 +571,6 @@ func handleInput(viewName string) error {
 		RunCommand(cmd...)
 	} else {
 		go sendChat(inputString)
-	}
-	// restore any tab completion view titles on input commit
-	if newViewTitle := getViewTitle(viewName); newViewTitle != "" {
-		setViewTitle(viewName, newViewTitle)
 	}
 
 	go populateList()


### PR DESCRIPTION
Moves the input box title correction to the beginning of `handleInput()` to prevent early return.  This prevents tab completion options from hanging around on command arguments like `/wall<TAB><ENTER>`