### PR TITLE
Adding `/exec` functionality

### DIFF
--- a/cmdExec.go
+++ b/cmdExec.go
@@ -1,0 +1,56 @@
+// +build !rm_basic_commands allcommands execcmd
+
+package main
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+func init() {
+	command := Command{
+		Cmd:         []string{"exec", "ex"},
+		Description: "$keybase args - executes keybase $args and returns the output",
+		Help:        "",
+		Exec:        cmdExec,
+	}
+	RegisterCommand(command)
+}
+
+func cmdExec(cmd []string) {
+	l := len(cmd)
+	switch {
+	case l >= 2:
+		if cmd[1] == "keybase" {
+			// if the user types /exec keybase wallet list
+			// only send ["wallet", "list"]
+			runKeybaseExec(cmd[2:])
+		} else {
+			// send everything except the command
+			runKeybaseExec(cmd[1:])
+		}
+	case l == 1:
+		fallthrough
+	default:
+		printExecHelp()
+	}
+}
+
+func runKeybaseExec(args []string) {
+	cmd := exec.Command("keybase", args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		printToView("Feed", fmt.Sprintf("Exec error: %+v", err))
+	} else {
+		channel.Name = ""
+		// unjoin the chat
+		clearView("Chat")
+		setViewTitle("Input", fmt.Sprintf(" /exec %s ", strings.Join(args, " ")))
+		printToView("Chat", fmt.Sprintf("%s", output))
+	}
+}
+
+func printExecHelp() {
+	printInfo(fmt.Sprintf("To execute a keybase command use %sexec <keybase args>", config.Basics.CmdPrefix))
+}

--- a/cmdExec.go
+++ b/cmdExec.go
@@ -4,7 +4,6 @@ package main
 
 import (
 	"fmt"
-	"os/exec"
 	"strings"
 )
 
@@ -38,8 +37,7 @@ func cmdExec(cmd []string) {
 }
 
 func runKeybaseExec(args []string) {
-	cmd := exec.Command("keybase", args...)
-	output, err := cmd.CombinedOutput()
+	outputBytes, err := k.Exec(args...)
 	if err != nil {
 		printToView("Feed", fmt.Sprintf("Exec error: %+v", err))
 	} else {
@@ -47,6 +45,7 @@ func runKeybaseExec(args []string) {
 		// unjoin the chat
 		clearView("Chat")
 		setViewTitle("Input", fmt.Sprintf(" /exec %s ", strings.Join(args, " ")))
+		output := string(outputBytes)
 		printToView("Chat", fmt.Sprintf("%s", output))
 	}
 }

--- a/cmdJoin.go
+++ b/cmdJoin.go
@@ -44,6 +44,7 @@ func cmdJoin(cmd []string) {
 		printInfoF("You are joining: $TEXT", config.Colors.Message.LinkKeybase.stylize(joinedName))
 		clearView("Chat")
 		setViewTitle("Input", fmt.Sprintf(" %s ", joinedName))
+		lastChat = joinedName
 		go populateChat()
 	default:
 		printInfo(fmt.Sprintf("To join a team use %sjoin <team> <channel>", config.Basics.CmdPrefix))

--- a/mage.go
+++ b/mage.go
@@ -93,7 +93,7 @@ func BuildAllCommandsT() {
 // Build kbtui with beta functionality
 func BuildBeta() {
 	mg.Deps(getRemotePackages)
-	if err := sh.Run("go", "build", "-tags", "allcommands showreactionscmd emojiList tabcompletion"); err != nil {
+	if err := sh.Run("go", "build", "-tags", "allcommands showreactionscmd tabcompletion execcmd"); err != nil {
 		defer func() {
 			exit(err)
 		}()

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ var (
 	channels    []keybase.Channel
 	stream      = false
 	lastMessage keybase.ChatAPI
+	lastChat    = ""
 	g           *gocui.Gui
 )
 
@@ -121,6 +122,13 @@ func initKeybindings() error {
 				return nil
 			}
 			return gocui.ErrQuit
+		}); err != nil {
+		return err
+	}
+	if err := g.SetKeybinding("", gocui.KeyCtrlZ, gocui.ModNone,
+		func(g *gocui.Gui, v *gocui.View) error {
+			cmdJoin([]string{"/join", lastChat})
+			return nil
 		}); err != nil {
 		return err
 	}


### PR DESCRIPTION
this adds exec functions that aree contained to the `keybase` command space.
adds CTRL-z as a global "take me back to where i was" function to restore the previous chat when displaying other information (after info functions remove you from the chat)