### PR TITLE
Fix list populate

### DIFF
--- a/main.go
+++ b/main.go
@@ -412,7 +412,7 @@ func populateChat() {
 		}
 	}
 	printToView("Chat", actuallyPrintMe)
-
+	go populateList()
 }
 func populateList() {
 	_, maxY := g.Size()


### PR DESCRIPTION
Quick PR to change `populateChat()` to call `populateList()` to mark messages as read when joining channel or refreshing chat with <CTRL>+z