### PR TITLE
Make 'dev' flag usable

### DIFF
--- a/cmdDev.go
+++ b/cmdDev.go
@@ -1,0 +1,33 @@
+// +build !rm_basic_commands allcommands devcmd
+
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+func init() {
+	command := Command{
+		Cmd:         []string{"dev"},
+		Description: "- Switch to dev channels",
+		Help:        "",
+		Exec:        cmdDev,
+	}
+
+	RegisterCommand(command)
+}
+
+func cmdDev(cmd []string) {
+	dev = !dev
+
+	printInfo(fmt.Sprintf("You have toggled the dev flag to %+v", dev))
+
+  if (lastChat != "") {
+    // Switching from regular to dev mode? Dev chats don't use channels. Let's strip the channel name.
+    n := ""
+    if (dev) { n = strings.Split(lastChat, "#")[0] } else { n = lastChat }
+    cmdJoin([]string{"/join", n})
+  }
+  go updateChatWindow() // Otherwise you won't be able to process incoming messages.
+}

--- a/cmdDev.go
+++ b/cmdDev.go
@@ -29,5 +29,4 @@ func cmdDev(cmd []string) {
     if (dev) { n = strings.Split(lastChat, "#")[0] } else { n = lastChat }
     cmdJoin([]string{"/join", n})
   }
-  //go updateChatWindow() // Otherwise you won't be able to process incoming messages.
 }

--- a/cmdDev.go
+++ b/cmdDev.go
@@ -29,5 +29,5 @@ func cmdDev(cmd []string) {
     if (dev) { n = strings.Split(lastChat, "#")[0] } else { n = lastChat }
     cmdJoin([]string{"/join", n})
   }
-  go updateChatWindow() // Otherwise you won't be able to process incoming messages.
+  //go updateChatWindow() // Otherwise you won't be able to process incoming messages.
 }

--- a/cmdJoin.go
+++ b/cmdJoin.go
@@ -41,6 +41,12 @@ func cmdJoin(cmd []string) {
 			channel.TopicName = ""
 			channel.MembersType = keybase.USER
 		}
+    if dev {
+        channel.TopicType = "dev"
+    } else {
+        channel.TopicType = "chat"
+    }
+
 		printInfoF("You are joining: $TEXT", config.Colors.Message.LinkKeybase.stylize(joinedName))
 		clearView("Chat")
 		setViewTitle("Input", fmt.Sprintf(" %s ", joinedName))

--- a/main.go
+++ b/main.go
@@ -42,6 +42,7 @@ func main() {
 	defer g.Close()
 	g.SetManagerFunc(layout)
 	RunCommand("config", "load")
+	if dev { channel.TopicType = "dev" } else { channel.TopicType = "chat" }
 	go populateList()
 	go updateChatWindow()
 	if len(os.Args) > 1 {
@@ -381,6 +382,7 @@ func populateChat() {
 			if channel.Name == testChan.Name {
 				channel = testChan
 				channel.TopicName = "general"
+				if dev { channel.TopicType = "dev" } else { channel.TopicType = "chat" }
 			}
 		}
 		chat = k.NewChat(channel)
@@ -602,8 +604,9 @@ func handleMessage(api keybase.ChatAPI) {
 				}
 			}
 			if api.Msg.Channel.MembersType == channel.MembersType && cleanChannelName(api.Msg.Channel.Name) == channel.Name {
-				if channel.MembersType == keybase.USER || channel.MembersType == keybase.TEAM && channel.TopicName == api.Msg.Channel.TopicName {
-					printToView("Chat", formatOutput(api).string())
+				if channel.MembersType == keybase.USER || channel.MembersType == keybase.TEAM && channel.TopicName == api.Msg.Channel.TopicName &&
+					channel.TopicType == api.Msg.Channel.TopicType {
+					printToView("Chat", formatOutput(api))
 					chat := k.NewChat(channel)
 					lastMessage.ID = api.Msg.ID
 					chat.Read(api.Msg.ID)

--- a/main.go
+++ b/main.go
@@ -363,7 +363,7 @@ func printToView(viewName string, message string) {
 func updateChatWindow() {
 
 	runOpts := keybase.RunOptions{
-		Dev: dev,
+		Dev: true,
 	}
 	k.Run(func(api keybase.ChatAPI) {
 		handleMessage(api)
@@ -604,11 +604,11 @@ func handleMessage(api keybase.ChatAPI) {
 			}
 			if api.Msg.Channel.MembersType == channel.MembersType && cleanChannelName(api.Msg.Channel.Name) == channel.Name {
 				if channel.MembersType == keybase.USER || channel.MembersType == keybase.TEAM && channel.TopicName == api.Msg.Channel.TopicName &&
-					channel.TopicType == api.Msg.Channel.TopicType {
-					printToView("Chat", formatOutput(api).string())
-					chat := k.NewChat(channel)
-					lastMessage.ID = api.Msg.ID
-					chat.Read(api.Msg.ID)
+					 (dev && api.Msg.Channel.TopicType == "dev" || !dev && api.Msg.Channel.TopicType == "chat") {
+						printToView("Chat", formatOutput(api).string())
+						chat := k.NewChat(channel)
+						lastMessage.ID = api.Msg.ID
+						chat.Read(api.Msg.ID)
 				}
 			}
 		} else {

--- a/main.go
+++ b/main.go
@@ -606,7 +606,7 @@ func handleMessage(api keybase.ChatAPI) {
 			if api.Msg.Channel.MembersType == channel.MembersType && cleanChannelName(api.Msg.Channel.Name) == channel.Name {
 				if channel.MembersType == keybase.USER || channel.MembersType == keybase.TEAM && channel.TopicName == api.Msg.Channel.TopicName &&
 					channel.TopicType == api.Msg.Channel.TopicType {
-					printToView("Chat", formatOutput(api))
+					printToView("Chat", formatOutput(api).string())
 					chat := k.NewChat(channel)
 					lastMessage.ID = api.Msg.ID
 					chat.Read(api.Msg.ID)

--- a/main.go
+++ b/main.go
@@ -42,7 +42,6 @@ func main() {
 	defer g.Close()
 	g.SetManagerFunc(layout)
 	RunCommand("config", "load")
-	if dev { channel.TopicType = "dev" } else { channel.TopicType = "chat" }
 	go populateList()
 	go updateChatWindow()
 	if len(os.Args) > 1 {


### PR DESCRIPTION
With this commit it becomes possible to set the dev flag to true, which will allow you to send and receive chat messages in dev channels only. You can use this to test kbtui without being disruptive.